### PR TITLE
pysam version 0.9.1.4 or above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 biopython
-pysam==0.9.1.4
+pysam>=0.9.1.4
 cython
 networkx==1.11
 scipy


### PR DESCRIPTION
Adapted requirements to take pysam of at least 0.9.1.4, and not necessarily exactly this version