### PR TITLE
Remove unnecessary viterbi on reverse complement

### DIFF
--- a/advntr/vntr_finder.py
+++ b/advntr/vntr_finder.py
@@ -361,6 +361,8 @@ class VNTRFinder:
 
     def check_if_pacbio_read_spans_vntr(self, sema, read, length_distribution, spanning_reads):
         self.check_if_flanking_regions_align_to_str(str(read.seq).upper(), read.query_name, length_distribution, spanning_reads)
+        reverse_complement_str = str(Seq(str(read.seq)).reverse_complement())
+        self.check_if_flanking_regions_align_to_str(reverse_complement_str.upper(), read.query_name, length_distribution, spanning_reads)
         sema.release()
 
     def check_if_pacbio_mapped_read_spans_vntr(self, sema, read, length_distribution, spanning_reads):

--- a/advntr/vntr_finder.py
+++ b/advntr/vntr_finder.py
@@ -361,8 +361,6 @@ class VNTRFinder:
 
     def check_if_pacbio_read_spans_vntr(self, sema, read, length_distribution, spanning_reads):
         self.check_if_flanking_regions_align_to_str(str(read.seq).upper(), read.query_name, length_distribution, spanning_reads)
-        reverse_complement_str = str(Seq(str(read.seq)).reverse_complement())
-        self.check_if_flanking_regions_align_to_str(reverse_complement_str.upper(), read.query_name, length_distribution, spanning_reads)
         sema.release()
 
     def check_if_pacbio_mapped_read_spans_vntr(self, sema, read, length_distribution, spanning_reads):
@@ -379,8 +377,6 @@ class VNTRFinder:
                     read_region_end = read_pos
             if read_region_start is not None and read_region_end is not None:
                 result_seq = read.seq[read_region_start:read_region_end+flanking_region_size]
-                if read.is_reverse:
-                    result_seq = str(Seq(result_seq).reverse_complement())
                 spanning_reads.append(LoggedRead(sequence=result_seq,
                                                  read_id=read.query_name,
                                                  source=LoggedRead.Source.MAPPED))
@@ -513,15 +509,11 @@ class VNTRFinder:
         vntr_matcher = self.build_vntr_matcher_hmm(max_copies)
         observed_copy_numbers = []
         for spanning_read in spanning_reads:
-            haplotype = spanning_read.sequence
-            logp, vpath = vntr_matcher.viterbi(haplotype)
-            rev_logp, rev_vpath = vntr_matcher.viterbi(str(Seq(haplotype).reverse_complement()))
-            if logp < rev_logp:
-                vpath = rev_vpath
+            read_sequence = spanning_read.sequence
+            logp, vpath = vntr_matcher.viterbi(read_sequence)
             repeats = get_number_of_repeats_in_vpath(vpath)
             observed_copy_numbers.append(repeats)
             if log_pacbio_reads:
-                read_sequence = str(Seq(haplotype))
                 logging.debug(read_sequence)
                 visited_states = [state.name for idx, state in vpath[1:-1]]
                 if self.read_flanks_repeats_with_confidence(vpath, read_sequence):
@@ -699,11 +691,6 @@ class VNTRFinder:
                 if read.seq.count('N') <= 0:
                     sequence = str(read.seq).upper()
                     logp, vpath = hmm.viterbi(sequence)
-                    rev_logp, rev_vpath = hmm.viterbi(str(Seq(read.seq).reverse_complement()).upper())
-                    if logp < rev_logp:
-                        sequence = str(Seq(read.seq).reverse_complement()).upper()
-                        logp = rev_logp
-                        vpath = rev_vpath
                     if is_low_quality_read(read) or not self.recruit_read(logp, vpath, recruitment_score, sequence):
                         logging.debug('Rejected Aligned Read: %s' % sequence)
                         continue


### PR DESCRIPTION
# Description

This commit fixes two bugs related to reverse complement.
1. Logging reverse complement sequence in PacBio mode.
2. Not calling Viterbi on reverse complement sequence.

## Details
### 1. Logging reverse complement sequence in PacBio mode.
- All sequence in log file is designed to be on "forward-strand". That is, all reads aligned to the reverse-strand should be reverse-complemented (converted to forward-strand) before logging.
- However, the logged sequence is reverse-complemented when it's mapped to the reverse-strand. (adVNTR code link)
- adVNTR reverse-complement the sequence when it's mapped to reverse-strand.
- But, it's already reverse-complemented by default (pysam)
-The confusion was introduced by the pysam library. The seq is automatically reverse-complemented. See pysam documentation (.seq is deprecated, but same as query_sequence).

Why does it matter?
- `pairwise_aln_generator.py` uses the logged sequence to generate an alignment file.
- The logged sequence should be always in "forward_strand" to match to HMM.
- However, we are logging reverse_complemented sequences if the sequence is mapped to the reverse_strand.
- That caused very poor alignment on the pairwise_alignment tool making reads filtered out in many cases.

### 2. Not calling Viterbi on reverse complement sequence.
If a read is mapped, we already know which strand the read is mapped. 
Therefore, we don't need to call Viterbi on both the sequence and the reverse complement of it because we know which sequence mapped to the reference (forward strand).
For unmapped reads, we try both and save the "forward sequence" that has the higher score.

It's expected that this fix reduces the running time significantly as Viterbi takes most of the running time.