### PR TITLE
Fix sequence slicing bug

### DIFF
--- a/advntr/vntr_finder.py
+++ b/advntr/vntr_finder.py
@@ -411,7 +411,7 @@ class VNTRFinder:
                 spanning_reads.append(LoggedRead(sequence=result_seq,
                                                  read_id=read.query_name,
                                                  source=LoggedRead.Source.MAPPED))
-                length_distribution.append(len(result_seq) - hmm_flanking_region_size * 2)
+                length_distribution.append(len(result_seq) - left_flanking_bp - right_flanking_bp)
         sema.release()
 
     @time_usage
@@ -558,7 +558,7 @@ class VNTRFinder:
 
         genotype_string = '/'.join([str(cn) for cn in sorted(copy_numbers)]) if copy_numbers is not None else 'None'
         logging.info('RU count lower bounds: %s' % genotype_string)
-        
+
         return copy_numbers, max_prob
 
     @time_usage

--- a/advntr/vntr_finder.py
+++ b/advntr/vntr_finder.py
@@ -553,7 +553,13 @@ class VNTRFinder:
                     logging.debug('flanking read %s sourced from %s visited states :%s' % (spanning_read.read_id, spanning_read.source.name, visited_states))
                 logging.debug('repeats: %s' % repeats)
         logging.info('observed repeats: %s' % observed_copy_numbers)
-        return self.find_genotype_based_on_observed_repeats(observed_copy_numbers)
+
+        copy_numbers, max_prob = self.find_genotype_based_on_observed_repeats(observed_copy_numbers)
+
+        genotype_string = '/'.join([str(cn) for cn in sorted(copy_numbers)]) if copy_numbers is not None else 'None'
+        logging.info('RU count lower bounds: %s' % genotype_string)
+        
+        return copy_numbers, max_prob
 
     @time_usage
     def get_haplotype_copy_numbers_from_spanning_reads(self, spanning_reads):


### PR DESCRIPTION
# Description

### Bug 1:
without full_length=True option, `get_reference_positions()` function doesn't output the soft clipped positions making the length of the list different from the read length. That caused the wrong indexing of the read sequence.

### Solution:
Use full_length option.

### Bug 2. 
When deletions occur in the read, the current algorithm may get sequences out of the boundary (+-100 bp flanking regions) because the read_region_start and read_region_end can be the same. 

For example,
reference: ---|left flanking region|TR region|right flanking region|---
---a read:      ---|DDDDDDDDDDDDDDDDDDDDDD*----------------|---

here, 'D' shows deleted bases against the reference sequence. This read has no sequence covering left flanking and the TR region. Only partially covers the right flanking region. But, this read will be recruited because it has alignment before the left flanking region, and after the right flanking region.
In this case, the `region_start` and `region_end` will be the same at the index of "\*" mark, and the final sequence sliced is seq[\*: \*+100], which is even out of HMM model boundary.

### Solution
Count how many bases (in HMM model) are covered by the read (in the TR region and flanking region), and filter the read if it doesn't have enough (10 bp for each flank) flanking regions.
Also, when slicing the read, only get the bp that has been covered.


