### PR TITLE
Save long VNTRs to the VNTR database

### DIFF
--- a/advntr/models.py
+++ b/advntr/models.py
@@ -161,7 +161,7 @@ def load_unique_vntrs_data(db_file=None):
     return vntrs
 
 
-def save_vntrs_to_database(processed_vntrs, db_file):
+def save_vntrs_to_database(processed_vntrs, db_file, vntr_length_threshold=10000):
     with open(processed_vntrs) as input_file:
         lines = input_file.readlines()
     db = sqlite3.connect(db_file)
@@ -171,6 +171,8 @@ def save_vntrs_to_database(processed_vntrs, db_file):
     for line in lines:
         line = line.strip()
         vntr_id, overlap, chromosome, start, gene, annotation, pattern, left_flank, right_flank, segments = line.split()
+        if len(segments.replace(',', '')) > vntr_length_threshold:
+                    continue
         cursor.execute('''INSERT INTO vntrs(id, nonoverlapping, chromosome, ref_start, gene_name, annotation, pattern,
                        left_flanking, right_flanking, repeats, scaled_score) VALUES(?,?,?,?,?,?,?,?,?,?,?)''',
                        (vntr_id, overlap, chromosome, start, gene, annotation, pattern, left_flank, right_flank,

--- a/advntr/models.py
+++ b/advntr/models.py
@@ -171,8 +171,6 @@ def save_vntrs_to_database(processed_vntrs, db_file):
     for line in lines:
         line = line.strip()
         vntr_id, overlap, chromosome, start, gene, annotation, pattern, left_flank, right_flank, segments = line.split()
-        if len(segments.replace(',', '')) > 150:
-            continue
         cursor.execute('''INSERT INTO vntrs(id, nonoverlapping, chromosome, ref_start, gene_name, annotation, pattern,
                        left_flanking, right_flanking, repeats, scaled_score) VALUES(?,?,?,?,?,?,?,?,?,?,?)''',
                        (vntr_id, overlap, chromosome, start, gene, annotation, pattern, left_flank, right_flank,

--- a/advntr/models.py
+++ b/advntr/models.py
@@ -172,7 +172,7 @@ def save_vntrs_to_database(processed_vntrs, db_file, vntr_length_threshold=10000
         line = line.strip()
         vntr_id, overlap, chromosome, start, gene, annotation, pattern, left_flank, right_flank, segments = line.split()
         if len(segments.replace(',', '')) > vntr_length_threshold:
-                    continue
+            continue
         cursor.execute('''INSERT INTO vntrs(id, nonoverlapping, chromosome, ref_start, gene_name, annotation, pattern,
                        left_flanking, right_flanking, repeats, scaled_score) VALUES(?,?,?,?,?,?,?,?,?,?,?)''',
                        (vntr_id, overlap, chromosome, start, gene, annotation, pattern, left_flank, right_flank,


### PR DESCRIPTION
Prior to this change, there was a constraint in the length of the VNTRs when saving into the SQL VNTR database. The constraint is removed now. Long VNTRs can be stored in VNTR database now.